### PR TITLE
Leave propertyUnit blank if not defined

### DIFF
--- a/src/bindstyle-ember-helper.js
+++ b/src/bindstyle-ember-helper.js
@@ -30,6 +30,10 @@ Ember.Handlebars.registerHelper('bindStyle', function(options) {
     {
       propertyUnit = attrs["unit"]; 
     } 
+    if(propertyUnit==undefined)
+    {
+      propertyUnit = '';
+    }
 
     ember_assert(fmt("You must provide at least a global unit that will be used for all style properties"), propertyUnit != null);
 


### PR DESCRIPTION
Making the unit property optional

so if you write `{{bindStyle color:"hexColor"}}` will not produce `color:#fffundefined;`
