### PR TITLE
jQuery.uuid has been removed

### DIFF
--- a/src/bindstyle-ember-helper.js
+++ b/src/bindstyle-ember-helper.js
@@ -65,7 +65,7 @@ Ember.Handlebars.registerHelper('bindStyle', function(options) {
     // unique data id and update the attribute to the new value.
     Ember.addObserver(ctx, property, invoker);
 
-    ret.push(attr+':'+value+propertyUnit+';'+(attrs["static"] || ''));
+    style.push(attr+':'+value+propertyUnit+';'+(attrs["static"] || ''));
   }, this);
 
   // Add the unique identifier


### PR DESCRIPTION
Since jQuery.uuid does not exist anymore I changed it to Ember.uuid

https://github.com/emberjs/ember.js/pull/1481

Every View with bound styles had data-bindattr-NaN="NaN"
