### PR TITLE
Missing propertyUnit on value change

### DIFF
--- a/src/bindstyle-ember-helper.js
+++ b/src/bindstyle-ember-helper.js
@@ -52,7 +52,7 @@ Ember.Handlebars.registerHelper('bindStyle', function(options) {
       var currentValue = elem.css(attr);
 
       if (currentValue !== result) {
-        elem.css(attr, result);
+        elem.css(attr, result+propertyUnit);
       }
     };
 


### PR DESCRIPTION
If the value updates and another property unit than `px` was used, it will be reset to `px`.
